### PR TITLE
Fix Clang CI Problem

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -16,14 +16,11 @@ jobs:
     strategy:
       matrix:
         compiler-version: [9,10,11,12]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
-    - name: Set up GCC
-      uses: egor-tensin/setup-gcc@v1
-      with:
-        version: ${{ matrix.compiler-version }}
-        platform: x64
+    - name: Setup GCC
+      run: sudo apt install gcc-${{ matrix.compiler-version }}
     - name: build
       run: |
         make install
@@ -40,14 +37,11 @@ jobs:
     strategy:
       matrix:
         compiler-version: [11,12,13,14,15]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Clang
-      uses: egor-tensin/setup-clang@v1
-      with:
-        version: ${{ matrix.compiler-version }}
-        platform: x64
+    - name: Setup clang
+      run: sudo apt install clang-${{ matrix.compiler-version }}
     - name: build
       run: |
         make install
@@ -61,7 +55,7 @@ jobs:
       shell: bash
 
   c-clang-format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: c-build-unit-test-clang
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -15,7 +15,7 @@ jobs:
   c-build-unit-test-gcc:
     strategy:
       matrix:
-        compiler-version: [9,10,11,12]
+        compiler-version: [10,11,12]
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
   c-build-unit-test-clang:
     strategy:
       matrix:
-        compiler-version: [11,12,13,14,15]
+        compiler-version: [12,13,14,15]
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Don't rely on external github action any longer.

Also fix ubuntu version to 22.04 (b/c this set of compiler versions is in this version's repo.